### PR TITLE
Fallback to the AWS SDK credentials flow if keys are not specified

### DIFF
--- a/lib/email-footprint/aws_common.rb
+++ b/lib/email-footprint/aws_common.rb
@@ -2,16 +2,21 @@ require 'aws-sdk'
 
 module EmailFootprint
   class AwsCommon
-    def self.credentials
-      Aws::Credentials.new(EmailFootprint.configuration.access_key_id,
-                           EmailFootprint.configuration.secret_access_key)
-    end
-
     def self.initialization_options
-      {
-        region:      EmailFootprint.configuration.aws_region,
-        credentials: EmailFootprint::AwsCommon.credentials
-      }
+      opts = {}
+
+      if EmailFootprint.configuration.access_key_id && EmailFootprint.configuration.secret_access_key
+        opts[:credentials] = Aws::Credentials.new(
+          EmailFootprint.configuration.access_key_id,
+          EmailFootprint.configuration.secret_access_key
+        )
+      end
+
+      if EmailFootprint.configuration.aws_region
+        opts[:region] = EmailFootprint.configuration.aws_region
+      end
+
+      opts
     end
   end
 end


### PR DESCRIPTION
We need to be able to get AWS region and keys from ENV variables or the instance metadata, but at the same time we need to maintain compatibility with the legacy configuration keys.